### PR TITLE
Add badge access token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -195,7 +195,7 @@ runs:
       if: contains(inputs.publish, 'true')
       run: |
         BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-        echo -e "![badge](https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ inputs.diff-storage }}/data/${{ env.diff_storage_branch }}/badge.svg)\n\n" > .coverage-output.final
+        echo -e "![badge](https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ inputs.diff-storage }}/data/${{ env.diff_storage_branch }}/badge.svg?token=${{ inputs.token }})\n\n" > .coverage-output.final
         echo -e "## Code Coverage Summary\n" >> .coverage-output.final
         echo -e "\`\`\`" >> .coverage-output.final
         cat .coverage-output >> .coverage-output.final


### PR DESCRIPTION
Private repositories require an access token to link to repository content (like `badge.svg`). This PR adds `inputs.token` to the URL that is posted in the comment on the pull request.