### PR TITLE
fix: Enable URL encoding for badge links

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -222,7 +222,9 @@ runs:
         BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
         if [[ "${{ steps.repository-visibility.outputs.result }}" == "public" ]]
         then {
-          echo -e "![badge](https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ inputs.diff-storage }}/data/${{ env.diff_storage_branch }}/badge.svg)\n\n" > .coverage-output.final
+          # URL encoding for branch name
+          URL_ENCODED_BRANCH=$(python3 -c 'import urllib.parse; print(urllib.parse.quote_plus("${{ env.diff_storage_branch }}"))')
+          echo -e "![badge](https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ inputs.diff-storage }}/data/${URL_ENCODED_BRANCH}/badge.svg)\n\n" > .coverage-output.final
         }
         else {
           echo -e "🧪 Test coverage: ${{ steps.coverage_percent.outputs.coverage_total }}%\n\n" > .coverage-output.final


### PR DESCRIPTION
URL encode branch names.
Fixes #32 