### PR TITLE
fix:same precision on coverage rates of current and diff branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -222,7 +222,7 @@ runs:
           pycobertura show ${{ inputs.diff-storage }}/data/${{ inputs.diff-branch }}/${{ inputs.storage-subdirectory }}/coverage.xml --output .coverage-output.diff-branch
           # Extract the total coverage percentage
           grep -E "^TOTAL " .coverage-output.diff-branch | \
-            awk '{printf "%.8f", (1 - $3/$2) * 100}' | tr -d '%' > .coverage-total.diff-branch
+            awk '{printf "%.8f", (1 - $3/$2) * 100}' > .coverage-total.diff-branch
           echo "Diff-branch coverage: $(cat .coverage-total.diff-branch)%"
         } else {
           echo "Diff-branch coverage file not found, cannot compare coverage rates."
@@ -234,7 +234,7 @@ runs:
     - name: Get total
       run: |
         grep -E "^TOTAL " .coverage-output | \
-          awk '{print $NF}' | tr -d '%' > .coverage-total
+          awk '{printf "%.8f", (1 - $3/$2) * 100}' > .coverage-total
       shell: bash
 
     - name: Store coverage percent


### PR DESCRIPTION
Minor fix following https://github.com/insightsengineering/coverage-action/pull/47. Addresses the following:

- Coverage rate being saved for the current wasn't following the `1e-8` precision used in the diff branch;
- Removed unneeded `tr -d '%'`. 

My bad on the suggestion I left on the PR missing these points 🥲

As an additional note, I thought about adding tests for these edge cases (80% on baseline, 80.000001% / 79.999999% on branches). However, it seems that `pycobertura show` counts line for each `<line />` element in the xml to a single line, so the mock files would require 1e9 lines to do so, which is far from ideal. Due to that, tests were left untouched.