### PR TITLE
ci: pin github actions to pull commit SHAs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Lint Code Base 👟
-        uses: github/super-linter/slim@v5
+        uses: github/super-linter/slim@45fc0d88288beee4701c62761281edfee85655d7 # v5.0.0
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create additional tags 🎟
-        uses: Actions-R-Us/actions-tagger@latest
+        uses: Actions-R-Us/actions-tagger@330ddfac760021349fef7ff62b372f2f691c20fb # v2.0.3
         with:
           publish_latest_tag: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -299,7 +299,7 @@ jobs:
             report-low-coverage-only: true
     steps:
       - name: Checkout Code 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run test on ${{ matrix.reports.path }} 🏃‍♀️
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -109,18 +109,18 @@ runs:
   using: composite
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.11'
 
     - name: Install pycobertura
-      uses: insightsengineering/pip-action@v2
+      uses: insightsengineering/pip-action@9252b12ade07a9e628ab42b90565beaa56e8b85c # v2.0.1
       with:
         packages: pycobertura==3.0.0
 
     - name: Get branch names
       id: branch-names
-      uses: tj-actions/branch-names@v7
+      uses: tj-actions/branch-names@6c999acf206f5561e19f46301bb310e9e70d8815 # v7.0.7
 
     - name: Generate text report
       run: |
@@ -138,7 +138,7 @@ runs:
       shell: bash
 
     - name: Fetch report from ${{ inputs.diff-storage }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         path: ${{ inputs.diff-storage }}
         fetch-depth: 0
@@ -146,7 +146,7 @@ runs:
 
     - name: Get token identity
       id: identity
-      uses: octokit/graphql-action@v2.x
+      uses: octokit/graphql-action@f7836e89a7e5bac63911bbe9653c21147b3d9bc3
       with:
         query: |
           query {
@@ -198,7 +198,7 @@ runs:
       shell: bash
 
     - name: Push storage branch
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@4cc74773234f74829a8c21bc4d69dd4be9cfa599
       with:
         github_token: ${{ inputs.token }}
         branch: ${{ inputs.diff-storage }}
@@ -261,7 +261,7 @@ runs:
 
     # Use the output from the `coverage_percent` step
     - name: Generate the badge SVG image
-      uses: emibcn/badge-action@v2.0.3
+      uses: emibcn/badge-action@808173dd03e2f30c980d03ee49e181626088eee8 # v2.0.3
       id: badge
       with:
         label: 'Test Coverage'
@@ -289,7 +289,7 @@ runs:
 
     # Badge has to be committed and pushed to be used in comment
     - name: Push badges
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@4cc74773234f74829a8c21bc4d69dd4be9cfa599
       with:
         github_token: ${{ inputs.token }}
         branch: ${{ inputs.diff-storage }}
@@ -298,7 +298,7 @@ runs:
     - name: Determine repository visibility
       if: contains(inputs.publish, 'true')
       id: repository-visibility
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         script: |
           const result = await github.rest.repos.get({
@@ -368,7 +368,7 @@ runs:
 
     - name: Post as comment
       if: contains(inputs.publish, 'true')
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
         header: ${{ inputs.path }}
@@ -399,7 +399,7 @@ runs:
     - name: Push XML report to ${{ inputs.diff-storage }}
       if: >
         contains(inputs.diff, 'true')
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@4cc74773234f74829a8c21bc4d69dd4be9cfa599
       with:
         github_token: ${{ inputs.token }}
         branch: ${{ inputs.diff-storage }}


### PR DESCRIPTION
This PR updates the GitHub Action workflows to use full length commit SHAs instead of mutable tags (e.g., @v2).
By pinning to a specific hash, we ensure that the code running in our CI/CD pipeline is exactly what we audited, protecting us from "tag shifting" where a version tag is moved to a different (potentially malicious) commit.

Using version tags like @v3 relies on trust that the maintainer’s account won't be compromised. If an attacker gains access to a dependency we use, they can push a malicious update to that tag, and our pipeline would automatically pull the compromised code. 

Reference Incident: https://github.com/aquasecurity/trivy-action/issues/541